### PR TITLE
The minitests no longer use deprecated syntax

### DIFF
--- a/test/label_part.rb
+++ b/test/label_part.rb
@@ -6,6 +6,6 @@ describe DiceBag::LabelPart do
   end
 
   it 'must return the value in parenthesis as a string' do
-    @part.to_s.must_equal '(test)'
+    _(@part.to_s).must_equal '(test)'
   end
 end

--- a/test/parser.rb
+++ b/test/parser.rb
@@ -7,23 +7,23 @@ describe DiceBag::Parser do
     end
 
     it 'should return an array' do
-      @parsed.must_be_instance_of Array
+      _(@parsed).must_be_instance_of Array
     end
 
     it 'should have a hash as the first element' do
-      @parsed.first.must_be_instance_of Hash
+      _(@parsed.first).must_be_instance_of Hash
     end
 
     it 'must have a :start key in the first hash element' do
-      @parsed.first.key?(:start).must_equal true
+      _(@parsed.first.key?(:start)).must_equal true
     end
 
     it 'must have an :xdx key in the :start hash' do
-      @parsed.first[:start].key?(:xdx).must_equal true
+      _(@parsed.first[:start].key?(:xdx)).must_equal true
     end
 
     it 'must have an :options key in the :start hash' do
-      @parsed.first[:start].key?(:options).must_equal true
+      _(@parsed.first[:start].key?(:options)).must_equal true
     end
   end
 
@@ -33,31 +33,31 @@ describe DiceBag::Parser do
     end
 
     it 'should return an array' do
-      @parsed.must_be_instance_of Array
+      _(@parsed).must_be_instance_of Array
     end
 
     it 'should have a hash as the first element' do
-      @parsed.first.must_be_instance_of Hash
+      _(@parsed.first).must_be_instance_of Hash
     end
 
     it 'must have a :start key in the first hash element' do
-      @parsed.first.key?(:start).must_equal true
+      _(@parsed.first.key?(:start)).must_equal true
     end
 
     it 'must have an :options key in the :start hash' do
-      @parsed.first[:start].key?(:options).must_equal true
+      _(@parsed.first[:start].key?(:options)).must_equal true
     end
 
     it 'must have an :xdx key in the :start hash' do
-      @parsed.first[:start].key?(:xdx).must_equal true
+      _(@parsed.first[:start].key?(:xdx)).must_equal true
     end
 
     it 'must have a count value in the :xdx hash' do
-      @parsed.first[:start][:xdx].key?(:count).must_equal true
+      _(@parsed.first[:start][:xdx].key?(:count)).must_equal true
     end
 
     it 'must have a sides value in the :xdx hash' do
-      @parsed.first[:start][:xdx].key?(:sides).must_equal true
+      _(@parsed.first[:start][:xdx].key?(:sides)).must_equal true
     end
   end
 end

--- a/test/result.rb
+++ b/test/result.rb
@@ -8,14 +8,14 @@ describe DiceBag::Result do
   end
 
   it 'must have 3 sections' do
-    @result.sections.size.must_equal 3
+    _(@result.sections.size).must_equal 3
   end
 
   it 'must have a total of 13' do
-    @result.total.must_equal 13
+    _(@result.total).must_equal 13
   end
 
   it 'must display a label and total string' do
-    @result.to_s.must_equal 'Dice Roll: 13'
+    _(@result.to_s).must_equal 'Dice Roll: 13'
   end
 end

--- a/test/roll.rb
+++ b/test/roll.rb
@@ -7,27 +7,27 @@ describe DiceBag::Roll do
 
   describe 'before it is rolled' do
     it 'should store the dice string' do
-      @roll.dstr.must_equal '(Dice Roll) 3d6 + 2 + 1d4'
+      _(@roll.dstr).must_equal '(Dice Roll) 3d6 + 2 + 1d4'
     end
 
     it 'should have parsed tree' do
-      @roll.tree.wont_be_nil
+      _(@roll.tree).wont_be_nil
     end
 
     it 'should have a parsed tree of 4 items' do
-      @roll.tree.size.must_equal 4
+      _(@roll.tree.size).must_equal 4
     end
 
     it 'should have a label part' do
-      @roll.tree[0].last.must_be_instance_of DiceBag::LabelPart
+      _(@roll.tree[0].last).must_be_instance_of DiceBag::LabelPart
     end
 
     it 'should have a roll part' do
-      @roll.tree[1].last.must_be_instance_of DiceBag::RollPart
+      _(@roll.tree[1].last).must_be_instance_of DiceBag::RollPart
     end
 
     it 'should have a static part' do
-      @roll.tree[2].last.must_be_instance_of DiceBag::StaticPart
+      _(@roll.tree[2].last).must_be_instance_of DiceBag::StaticPart
     end
   end
 
@@ -39,15 +39,15 @@ describe DiceBag::Roll do
     end
 
     it 'should have a non-nil result' do
-      @roll.result.wont_be_nil
+      _(@roll.result).wont_be_nil
     end
 
     it 'should have a DiceBag::Result value' do
-      @roll.result.must_be_instance_of DiceBag::Result
+      _(@roll.result).must_be_instance_of DiceBag::Result
     end
 
     it 'should have a result total of 16' do
-      @roll.result.total.must_equal 16
+      _(@roll.result.total).must_equal 16
     end
   end
 end

--- a/test/roll_part.rb
+++ b/test/roll_part.rb
@@ -9,19 +9,19 @@ describe DiceBag::RollPart do
 
       describe 'before it rolls' do
         it 'must not have rolled' do
-          @part.rolled?.must_equal false
+          _(@part.rolled?).must_equal false
         end
 
         it 'has an empty tally' do
-          @part.tally.must_be_empty
+          _(@part.tally).must_be_empty
         end
 
         it 'must have count of 3' do
-          @part.count.must_equal 3
+          _(@part.count).must_equal 3
         end
 
         it 'must have 6 sides' do
-          @part.sides.must_equal 6
+          _(@part.sides).must_equal 6
         end
       end
 
@@ -33,19 +33,19 @@ describe DiceBag::RollPart do
         end
 
         it 'should have rolled' do
-          @part.rolled?.must_equal true
+          _(@part.rolled?).must_equal true
         end
 
         it 'must have a total of 11' do
-          @part.total.must_equal 11
+          _(@part.total).must_equal 11
         end
 
         it 'must have a tally' do
-          @part.tally.wont_be_empty
+          _(@part.tally).wont_be_empty
         end
 
         it 'must have a tally with 3 items' do
-          @part.tally.size.must_equal 3
+          _(@part.tally.size).must_equal 3
         end
       end
     end
@@ -60,12 +60,12 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 14' do
-        @part.total.must_equal 14
+        _(@part.total).must_equal 14
       end
 
       it 'should have a tally of 4 items' do
-        @part.tally[0].size.must_equal 3
-        @part.tally[1].size.must_equal 1
+        _(@part.tally[0].size).must_equal 3
+        _(@part.tally[1].size).must_equal 1
       end
     end
 
@@ -79,11 +79,11 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 21' do
-        @part.total.must_equal 21
+        _(@part.total).must_equal 21
       end
 
       it 'should explode 5 times' do
-        @part.tally.size.must_equal 5
+        _(@part.tally.size).must_equal 5
       end
     end
 
@@ -97,11 +97,11 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 10' do
-        @part.total.must_equal 10
+        _(@part.total).must_equal 10
       end
 
       it 'should have a tally of 3 items' do
-        @part.tally.size.must_equal 3
+        _(@part.tally.size).must_equal 3
       end
     end
 
@@ -115,11 +115,11 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 6' do
-        @part.total.must_equal 6
+        _(@part.total).must_equal 6
       end
 
       it 'should have a tally of 3 items' do
-        @part.tally.size.must_equal 3
+        _(@part.tally.size).must_equal 3
       end
     end
   end
@@ -135,7 +135,7 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 2' do
-        @part.total.must_equal 2
+        _(@part.total).must_equal 2
       end
     end
 
@@ -149,12 +149,12 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 2' do
-        @part.total.must_equal 3
+        _(@part.total).must_equal 3
       end
 
       it 'should have a tally of 3 items and 3 rerolls' do
-        @part.tally[0].size.must_equal 3
-        @part.tally[1].size.must_equal 3
+        _(@part.tally[0].size).must_equal 3
+        _(@part.tally[1].size).must_equal 3
       end
     end
 
@@ -168,11 +168,11 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 2' do
-        @part.total.must_equal 2
+        _(@part.total).must_equal 2
       end
 
       it 'should have a tally of 3 items' do
-        @part.tally.size.must_equal 3
+        _(@part.tally.size).must_equal 3
       end
     end
 
@@ -186,11 +186,11 @@ describe DiceBag::RollPart do
       end
 
       it 'should have a total of 1' do
-        @part.total.must_equal 1
+        _(@part.total).must_equal 1
       end
 
       it 'should have a tally of 3 items' do
-        @part.tally.size.must_equal 3
+        _(@part.tally.size).must_equal 3
       end
     end
   end

--- a/test/roll_part_string.rb
+++ b/test/roll_part_string.rb
@@ -8,10 +8,10 @@ describe RollPartString do
   end
 
   it 'should reproduce the ROLL_PART_DSTR with spaces by default' do
-    @part.to_s.must_equal ROLL_PART_DSTR
+    _(@part.to_s).must_equal ROLL_PART_DSTR
   end
 
   it 'should reproduce the ROLL_PART_DSTR without spaces with a true value' do
-    @part.to_s(true).must_equal ROLL_PART_DSTR.tr(' ', '')
+    _(@part.to_s(true)).must_equal ROLL_PART_DSTR.tr(' ', '')
   end
 end

--- a/test/roll_string.rb
+++ b/test/roll_string.rb
@@ -8,10 +8,10 @@ describe RollString do
   end
 
   it 'should reproduce the ROLL_DSTR with spaces by default' do
-    @roll.to_s.must_equal ROLL_DSTR
+    _(@roll.to_s).must_equal ROLL_DSTR
   end
 
   it 'should reproduce the ROLL_DSTR without spaces with a true value' do
-    @roll.to_s(true).must_equal ROLL_DSTR.tr(' ', '')
+    _(@roll.to_s(true)).must_equal ROLL_DSTR.tr(' ', '')
   end
 end

--- a/test/simple_part.rb
+++ b/test/simple_part.rb
@@ -6,10 +6,10 @@ describe DiceBag::SimplePart do
   end
 
   it 'should return the value as a result' do
-    @part.result.must_equal 'test'
+    _(@part.result).must_equal 'test'
   end
 
   it 'should be the value as a string' do
-    @part.to_s.must_equal 'test'
+    _(@part.to_s).must_equal 'test'
   end
 end

--- a/test/static_part.rb
+++ b/test/static_part.rb
@@ -6,14 +6,14 @@ describe DiceBag::StaticPart do
   end
 
   it 'always uses an fixnum' do
-    @part.value.must_be_instance_of Fixnum
+    _(@part.value).must_be_instance_of Integer
   end
 
   it 'returns the value as the total' do
-    @part.total.must_equal 5
+    _(@part.total).must_equal 5
   end
 
   it 'return the value as a string when converted to a string' do
-    @part.to_s.must_equal '5'
+    _(@part.to_s).must_equal '5'
   end
 end

--- a/test/transform.rb
+++ b/test/transform.rb
@@ -8,31 +8,31 @@ describe DiceBag::Transform do
     end
 
     it 'should return an array' do
-      @ast.must_be_instance_of Array
+      _(@ast).must_be_instance_of Array
     end
 
     it 'should have an array as the first element' do
-      @ast.first.must_be_instance_of Array
+      _(@ast.first).must_be_instance_of Array
     end
 
     it 'must have a :start op in the first element' do
-      @ast.first[0].must_equal :start
+      _(@ast.first[0]).must_equal :start
     end
 
     it 'must have an :xdx key in the :start op hash' do
-      @ast.first[1].key?(:xdx).must_equal true
+      _(@ast.first[1].key?(:xdx)).must_equal true
     end
 
     it 'must have an :options key in the :start op hash' do
-      @ast.first[1].key?(:options).must_equal true
+      _(@ast.first[1].key?(:options)).must_equal true
     end
 
     it 'must have 2 dice in the tree' do
-      @ast.first[1][:xdx][:count].must_equal 2
+      _(@ast.first[1][:xdx][:count]).must_equal 2
     end
 
     it 'must have 6-sided dice in the tree' do
-      @ast.first[1][:xdx][:sides].must_equal 6
+      _(@ast.first[1][:xdx][:sides]).must_equal 6
     end
   end
 
@@ -43,7 +43,7 @@ describe DiceBag::Transform do
     end
 
     it 'must default to having 1 die' do
-      @ast.first[1][:xdx][:count].must_equal 1
+      _(@ast.first[1][:xdx][:count]).must_equal 1
     end
   end
 end


### PR DESCRIPTION
The minitests weren't running properly.
They were doing:
obj.must_equal instead of _(obj).must_equal

Also, static_part.rb used Fixnum, which is deprecated in Ruby 2.4